### PR TITLE
Fix silent 20-day prod scrape outage (OIDC audience) + never-awaited prefetch

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -221,7 +221,12 @@ fi
 
 # Prepare environment variables
 SCHEDULER_SA_FOR_ENV="scheduler-invoker@${PROJECT_ID}.iam.gserviceaccount.com"
-ENV_VARS="ENVIRONMENT=production,NTFY_TOPIC=westside-events-scraper,SCRAPER_INVOKER_SA=${SCHEDULER_SA_FOR_ENV}"
+# SCRAPER_AUDIENCE: the OIDC token audience Cloud Scheduler sends. Must match
+# the URL the service is invoked at (the *.a.run.app form). The app also accepts
+# the request's own URL as a fallback, but pin it here so deploys (which use
+# --set-env-vars and would otherwise wipe it) keep the scheduler authenticated.
+SCRAPER_AUDIENCE_FOR_ENV="https://westside-events-b4x4r2zv7a-uw.a.run.app"
+ENV_VARS="ENVIRONMENT=production,NTFY_TOPIC=westside-events-scraper,SCRAPER_INVOKER_SA=${SCHEDULER_SA_FOR_ENV},SCRAPER_AUDIENCE=${SCRAPER_AUDIENCE_FOR_ENV}"
 
 # Add environment variables from file if provided
 if [ -n "$ENV_FILE" ]; then

--- a/src/utils/async_scraper.py
+++ b/src/utils/async_scraper.py
@@ -22,7 +22,6 @@ class AsyncHTTPClient:
         """
         self.max_concurrent = max_concurrent
         self.delay = delay
-        self.semaphore = asyncio.Semaphore(max_concurrent)
         self.headers = {
             'User-Agent': config.SCRAPER_CONFIG['user_agent']
         }
@@ -30,6 +29,7 @@ class AsyncHTTPClient:
     async def fetch(self,
                    session: aiohttp.ClientSession,
                    url: str,
+                   semaphore: asyncio.Semaphore,
                    timeout: int = 30) -> Optional[str]:
         """
         Fetch a single URL asynchronously.
@@ -37,12 +37,13 @@ class AsyncHTTPClient:
         Args:
             session: aiohttp session
             url: URL to fetch
+            semaphore: Concurrency limiter bound to the running loop
             timeout: Request timeout in seconds
 
         Returns:
             HTML content or None if failed
         """
-        async with self.semaphore:
+        async with semaphore:
             try:
                 # Small delay between requests for politeness
                 if self.delay > 0:
@@ -66,14 +67,26 @@ class AsyncHTTPClient:
         Returns:
             List of HTML contents (None for failed requests)
         """
+        # Create the semaphore inside the coroutine so it binds to the loop
+        # that actually runs fetch_multiple (which may be a fresh loop spun up
+        # by fetch_all_sync's thread fallback), not whatever loop happened to
+        # exist at construction time.
+        semaphore = asyncio.Semaphore(self.max_concurrent)
         connector = aiohttp.TCPConnector(limit_per_host=self.max_concurrent)
         async with aiohttp.ClientSession(connector=connector, cookies=cookies) as session:
-            tasks = [self.fetch(session, url) for url in urls]
+            tasks = [self.fetch(session, url, semaphore) for url in urls]
             return await asyncio.gather(*tasks)
 
     def fetch_all_sync(self, urls: List[str], cookies: Optional[Dict[str, str]] = None) -> List[Optional[str]]:
         """
         Synchronous wrapper for async fetch_multiple.
+
+        Safe to call from a synchronous context with no event loop (uses
+        asyncio.run) AND from inside an already-running event loop (e.g. when a
+        scraper's scrape() is awaited directly rather than run in a thread): in
+        that case asyncio.run() would raise "cannot be called from a running
+        event loop", so we run the coroutine in a dedicated worker thread with
+        its own loop.
 
         Args:
             urls: List of URLs to fetch
@@ -82,7 +95,20 @@ class AsyncHTTPClient:
         Returns:
             List of HTML contents
         """
-        return asyncio.run(self.fetch_multiple(urls, cookies=cookies))
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop running on this thread — safe to drive one directly.
+            return asyncio.run(self.fetch_multiple(urls, cookies=cookies))
+
+        # A loop is already running on this thread; offload to a separate
+        # thread so we don't try to nest asyncio.run inside it.
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(
+                lambda: asyncio.run(self.fetch_multiple(urls, cookies=cookies))
+            )
+            return future.result()
 
 
 class BatchScraper:

--- a/src/web/routes/api.py
+++ b/src/web/routes/api.py
@@ -78,10 +78,28 @@ def setup_routes(rt, state):
                 'SCRAPER_INVOKER_SA',
                 'scheduler-invoker@westside-la-events.iam.gserviceaccount.com',
             )
-            expected_audience = os.getenv(
-                'SCRAPER_AUDIENCE',
-                'https://westside-events-406046958598.us-west1.run.app',
-            )
+
+            # Accept the token if its audience matches any configured value OR
+            # this request's own URL. Cloud Run services are reachable under
+            # multiple hostnames (legacy run.app + new *.a.run.app), and the
+            # serving URL can change; pinning a single hardcoded audience meant
+            # a URL change silently 401'd every scheduled scrape. SCRAPER_AUDIENCE
+            # may be a comma-separated list of explicit overrides.
+            accepted_audiences = {
+                a.strip()
+                for a in os.getenv('SCRAPER_AUDIENCE', '').split(',')
+                if a.strip()
+            }
+            # The scheduler's token audience is the URL it targeted, which is
+            # this request's URL (full path) or its base. Add both so we adapt
+            # to whatever hostname actually served the request. Behind Cloud
+            # Run the scheme may arrive as http (TLS terminated upstream) while
+            # the token audience is https, so accept both schemes.
+            netloc = request.url.netloc
+            path = request.url.path
+            for scheme in ('https', 'http'):
+                accepted_audiences.add(f"{scheme}://{netloc}")
+                accepted_audiences.add(f"{scheme}://{netloc}{path}")
 
             auth_header = request.headers.get('Authorization', '')
             bearer_prefix = 'Bearer '
@@ -90,11 +108,21 @@ def setup_routes(rt, state):
             token = auth_header[len(bearer_prefix):].strip()
 
             try:
+                # Verify signature/expiry now; check the audience ourselves
+                # against the accepted set below (verify_oauth2_token only takes
+                # a single audience string).
                 claims = id_token.verify_oauth2_token(
-                    token, google_requests.Request(), audience=expected_audience
+                    token, google_requests.Request()
                 )
             except ValueError as e:
                 logger.warning(f"OIDC token verification failed: {e}")
+                return JSONResponse({'error': 'Unauthorized'}, status_code=401)
+
+            if claims.get('aud') not in accepted_audiences:
+                logger.warning(
+                    f"OIDC token had wrong audience: aud={claims.get('aud')} "
+                    f"not in {sorted(accepted_audiences)}"
+                )
                 return JSONResponse({'error': 'Unauthorized'}, status_code=401)
 
             if claims.get('email') != expected_sa or not claims.get('email_verified'):


### PR DESCRIPTION
## Summary

Diagnosed and fixed a **silent ~20-day production outage** of the daily scheduled scrape. The site looked alive (recurring/future events persisted) but no new data had been written since **2026-06-04** — e.g. Westside Comedy decayed from a full slate to 2 events.

**Root cause:** Cloud Scheduler's daily `POST /api/run-scrapers` was getting **401 every run**. The endpoint pinned a single hardcoded OIDC token audience (the legacy `…406046958598…` Cloud Run URL), but the service URL had changed to the `…b4x4r2zv7a…a.run.app` form, so the scheduler token's audience never matched.

## Changes

1. **URL-resilient scrape auth** (`src/web/routes/api.py`) — verify the token signature, then accept the audience if it matches `SCRAPER_AUDIENCE` (now a comma-separated list) **or the request's own URL** (both http/https schemes, to handle TLS terminated upstream). A future Cloud Run URL change now self-heals instead of silently 401-ing. The service-account email check — the real security gate — is unchanged.

2. **Loop-aware async fetch** (`src/utils/async_scraper.py`) — `fetch_all_sync` used `asyncio.run()`, which throws "cannot be called from a running event loop" when a scraper's `scrape()` is awaited directly, leaking the `fetch_multiple` coroutine and breaking `WestsideComedy._scrape_website()`. It now offloads to a worker thread when a loop is already running, and builds the semaphore per-call so it binds to the running loop.

3. **Persist `SCRAPER_AUDIENCE` in deploy** (`scripts/deploy.sh`) — the deploy uses `--set-env-vars` (replaces all env), which would otherwise wipe the manually-set audience var.

## Operational fixes already applied to prod (out-of-band, before this PR)

- Set `SCRAPER_AUDIENCE` env on the Cloud Run service and routed traffic to the new revision → scheduler authenticates again.
- Deleted a redundant, token-less duplicate scheduler job (`scrape-westside-events`).
- Manually triggered `scrape-daily` → **200**, fresh data landed (`updated_at` now current; Westside Comedy back to 14 upcoming events).

## Testing

- 120 relevant unit/integration tests pass (incl. all web-app tests); syntax clean.
- Verified `WestsideComedy.scrape()` runs from within a running event loop with **no `RuntimeWarning`** (previously crashed).

## Follow-up (not in this PR)

Fixing the crash exposed pre-existing parser rot: `WestsideComedy._fetch_eventbrite_event_by_id()` returns `None` for valid Eventbrite event pages, so the website→per-ID path yields 0 (events still arrive via the organizer path). Tracked separately.

Related to #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)